### PR TITLE
Enable clang-cl build.

### DIFF
--- a/config_asm.h
+++ b/config_asm.h
@@ -91,7 +91,7 @@
 	#endif
 #endif
 
-#if defined(_MSC_VER) && defined(_M_X64)
+#if defined(_MSC_VER) && defined(_M_X64) && !defined(__clang__)
 	#define CRYPTOPP_X64_MASM_AVAILABLE 1
 #endif
 

--- a/config_cxx.h
+++ b/config_cxx.h
@@ -217,7 +217,7 @@
 // Also see https://github.com/weidai11/cryptopp/issues/980. I'm not sure what
 // to do when the compiler defines __cpp_lib_uncaught_exceptions but the platform
 // does not support std::uncaught_exceptions. What was Apple thinking???
-#if defined(__clang__)
+#if defined(__clang__) && !defined(CRYPTOPP_MSC_VERSION)
 # if __EXCEPTIONS && __has_feature(cxx_exceptions)
 #  if __cpp_lib_uncaught_exceptions >= 201411L
 #   define CRYPTOPP_CXX17_UNCAUGHT_EXCEPTIONS 1

--- a/config_os.h
+++ b/config_os.h
@@ -29,7 +29,7 @@
 // https://www.cryptopp.com/wiki/Release_Process#Self_Tests
 // The problems with Clang pretending to be other compilers is
 // discussed at http://github.com/weidai11/cryptopp/issues/147.
-#if (defined(_MSC_VER) && defined(__clang__))
+#if (defined(_MSC_VER) && _MSC_VER < 1930 && defined(__clang__))
 # error: "Unsupported configuration"
 #endif
 
@@ -126,6 +126,7 @@
 #endif
 
 #ifdef CRYPTOPP_WIN32_AVAILABLE
+#include <winapifamily.h>
 # if !defined(WINAPI_FAMILY)
 #	define THREAD_TIMER_AVAILABLE
 # elif defined(WINAPI_FAMILY)

--- a/secblock.h
+++ b/secblock.h
@@ -270,7 +270,7 @@ public:
 	/// \details VS.NET STL enforces the policy of "All STL-compliant allocators
 	///  have to provide a template class member called rebind".
     template <class V> struct rebind { typedef AllocatorWithCleanup<V, T_Align16> other; };
-#if (CRYPTOPP_MSC_VERSION >= 1500)
+#if (CRYPTOPP_MSC_VERSION >= 1500) || (defined(CRYPTOPP_MSC_VERSION) && defined(__clang__))
 	AllocatorWithCleanup() {}
 	template <class V, bool A> AllocatorWithCleanup(const AllocatorWithCleanup<V, A> &) {}
 #endif

--- a/zdeflate.cpp
+++ b/zdeflate.cpp
@@ -413,12 +413,12 @@ unsigned int Deflator::LongestMatch(unsigned int &bestMatch) const
 		{
 			CRYPTOPP_ASSERT(scan[2] == match[2]);
 			unsigned int len = (unsigned int)(
-#if defined(_STDEXT_BEGIN) && !(defined(CRYPTOPP_MSC_VERSION) && (CRYPTOPP_MSC_VERSION < 1400 || CRYPTOPP_MSC_VERSION >= 1600)) && !defined(_STLPORT_VERSION)
+#if defined(_STDEXT_BEGIN) && !(defined(CRYPTOPP_MSC_VERSION) && (CRYPTOPP_MSC_VERSION < 1400 || CRYPTOPP_MSC_VERSION >= 1600)) && !defined(_STLPORT_VERSION) && !defined(__clang__)
 				stdext::unchecked_mismatch
 #else
 				std::mismatch
 #endif
-#if CRYPTOPP_MSC_VERSION >= 1600
+#if CRYPTOPP_MSC_VERSION >= 1600 && !defined(__clang__)
 				(stdext::make_unchecked_array_iterator(scan)+3, stdext::make_unchecked_array_iterator(scanEnd), stdext::make_unchecked_array_iterator(match)+3).first - stdext::make_unchecked_array_iterator(scan));
 #else
 				(scan+3, scanEnd, match+3).first - scan);


### PR DESCRIPTION
Based on [vcpkg patches](https://github.com/microsoft/vcpkg/tree/master/ports/cryptopp), with some tweaks and an ASM fix.